### PR TITLE
Add option disable_popover

### DIFF
--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -60,6 +60,7 @@ typedef enum : NSUInteger {
     BOOL allow_video = [[options objectForKey:@"allow_video" ] boolValue ];
     NSString * title = [options objectForKey:@"title"];
     NSString * message = [options objectForKey:@"message"];
+	BOOL disable_popover = [[options objectForKey:@"disable_popover" ] boolValue];
     if (message == (id)[NSNull null]) {
       message = nil;
     }
@@ -68,10 +69,10 @@ typedef enum : NSUInteger {
     self.quality = [[options objectForKey:@"quality"] integerValue];
 
     self.callbackId = command.callbackId;
-    [self launchGMImagePicker:allow_video title:title message:message];
+    [self launchGMImagePicker:allow_video title:title message:message disable_popover:disable_popover];
 }
 
-- (void)launchGMImagePicker:(bool)allow_video title:(NSString *)title message:(NSString *)message
+- (void)launchGMImagePicker:(bool)allow_video title:(NSString *)title message:(NSString *)message disable_popover:(BOOL)disable_popover
 {
     GMImagePickerController *picker = [[GMImagePickerController alloc] init:allow_video];
     picker.delegate = self;
@@ -80,12 +81,15 @@ typedef enum : NSUInteger {
     picker.colsInPortrait = 4;
     picker.colsInLandscape = 6;
     picker.minimumInteritemSpacing = 2.0;
-    picker.modalPresentationStyle = UIModalPresentationPopover;
 
-    UIPopoverPresentationController *popPC = picker.popoverPresentationController;
-    popPC.permittedArrowDirections = UIPopoverArrowDirectionAny;
-    popPC.sourceView = picker.view;
-    //popPC.sourceRect = nil;
+	if(!disable_popover) {
+	    picker.modalPresentationStyle = UIModalPresentationPopover;
+
+	    UIPopoverPresentationController *popPC = picker.popoverPresentationController;
+	    popPC.permittedArrowDirections = UIPopoverArrowDirectionAny;
+	    popPC.sourceView = picker.view;
+	    //popPC.sourceRect = nil;
+	}
 
     [self.viewController showViewController:picker sender:nil];
 }

--- a/www/imagepicker.js
+++ b/www/imagepicker.js
@@ -1,7 +1,7 @@
 /*global cordova,window,console*/
 /**
  * An Image Picker plugin for Cordova
- * 
+ *
  * Developed by Wymsee for Sync OnSet
  */
 
@@ -36,14 +36,14 @@ ImagePicker.prototype.requestReadPermission = function(callback) {
 *	success - success callback
 *	fail - error callback
 *	options
-*		.maximumImagesCount - max images to be selected, defaults to 15. If this is set to 1, 
+*		.maximumImagesCount - max images to be selected, defaults to 15. If this is set to 1,
 *		                      upon selection of a single image, the plugin will return it.
 *		.width - width to resize image to (if one of height/width is 0, will resize to fit the
 *		         other while keeping aspect ratio, if both height and width are 0, the full size
 *		         image will be returned)
 *		.height - height to resize image to
 *		.quality - quality of resized image, defaults to 100
-*       .outputType - type of output returned. defaults to file URIs. 
+*       .outputType - type of output returned. defaults to file URIs.
 *					  Please see ImagePicker.OutputType for available values.
 */
 ImagePicker.prototype.getPictures = function(success, fail, options) {
@@ -52,7 +52,7 @@ ImagePicker.prototype.getPictures = function(success, fail, options) {
 	}
 
 	this.validateOutputType(options);
-	
+
 	var params = {
 		maximumImagesCount: options.maximumImagesCount ? options.maximumImagesCount : 15,
 		width: options.width ? options.width : 0,
@@ -61,9 +61,10 @@ ImagePicker.prototype.getPictures = function(success, fail, options) {
 		allow_video: options.allow_video ? options.allow_video : false,
 		title: options.title ? options.title : 'Select an Album', // the default is the message of the old plugin impl
 		message: options.message ? options.message : null, // the old plugin impl didn't have it, so passing null by default
-		outputType: options.outputType ? options.outputType : this.OutputType.FILE_URI
+		outputType: options.outputType ? options.outputType : this.OutputType.FILE_URI,
+		disable_popover: options.disable_popover ? options.disable_popover : false // Disable the iOS popover as seen on iPad
 	};
-	
+
 	return cordova.exec(success, fail, "ImagePicker", "getPictures", [params]);
 };
 


### PR DESCRIPTION
Sometimes, you want to display a fullscreen imagePicker instead of a popover on iPad. This is now possible by setting the option disable_popover to true.

(Also cleaned up www/imagepicker.js :smiley:)