### PR TITLE
Android: Fixed rotation issue during processing

### DIFF
--- a/src/android/Library/src/MultiImageChooserActivity.java
+++ b/src/android/Library/src/MultiImageChooserActivity.java
@@ -52,6 +52,7 @@ import android.content.CursorLoader;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.Loader;
+import android.content.pm.ActivityInfo;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -318,6 +319,7 @@ public class MultiImageChooserActivity extends AppCompatActivity implements
             progress.dismiss();
             finish();
         } else {
+	        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_NOSENSOR); //prevent orientation changes during processing
             new ResizeImagesTask().execute(fileNames.entrySet());
         }
     }


### PR DESCRIPTION
First Eddy thank you for putting together a complete image-picker repository! The original one is not being maintained anymore (as it seems) and important fixes like android 6.0 permissions are waiting for years to be pulled. Anyways, I've found the following bug:
1. Select some photos (5 or more)
2. During the progress dialog rotate the screen
3. Wait.
4. Crash.

What is happening?
- During rotation the activity is destroyed and a new one is generated
- The background process is still running, referencing the old activity
- When the process returns the progress dialog is dismissed, which is a leaked window

Resulting Exception:
`08-03 10:37:31.279 7709-7709/com.MYAPP E/AndroidRuntime: FATAL EXCEPTION: main
                                                                      Process: com.MYAPP, PID: 7709
                                                                      java.lang.IllegalArgumentException: View=com.android.internal.policy.PhoneWindow$DecorView{2231f8b V.E...... R......D 0,0-1026,483} not attached to window manager
                                                                          at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:424)
                                                                          at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:350)
                                                                          at android.view.WindowManagerImpl.removeViewImmediate(WindowManagerImpl.java:116)
                                                                          at android.app.Dialog.dismissDialog(Dialog.java:362)
                                                                          at android.app.Dialog.dismiss(Dialog.java:345)
                                                                          at com.synconset.MultiImageChooserActivity$ResizeImagesTask.onPostExecute(MultiImageChooserActivity.java:616)
                                                                          at com.synconset.MultiImageChooserActivity$ResizeImagesTask.onPostExecute(MultiImageChooserActivity.java:506)
                                                                          at android.os.AsyncTask.finish(AsyncTask.java:651)
                                                                          at android.os.AsyncTask.-wrap1(AsyncTask.java)
                                                                          at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:668)
                                                                          at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                          at android.os.Looper.loop(Looper.java:148)
                                                                          at android.app.ActivityThread.main(ActivityThread.java:5417)
                                                                          at java.lang.reflect.Method.invoke(Native Method)
                                                                          at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
                                                                          at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)`

The Fix:
Disabling the orientation changes when processing is started. A better solution could be to keep allowing rotation, but retaining the asyncTask between orientation changes is impossible (as far as I know) without using a service. Furthermore blocking the orientation change -after- the processing has started does not impact user experience in a big way. 

Related issue:
- not retaining the selected images between rotation changes issue #19 


