### PR TITLE
Remove line ending for image base64 encoding on iOS

### DIFF
--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -187,7 +187,7 @@ typedef enum : NSUInteger {
             // no scaling required
             if (self.outputType == BASE64_STRING){
                 UIImage* image = [UIImage imageNamed:item.image_fullsize];
-                [result_all addObject:[UIImageJPEGRepresentation(image, self.quality/100.0f) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength]];
+                [result_all addObject:[UIImageJPEGRepresentation(image, self.quality/100.0f) base64EncodedStringWithOptions:0]];
             } else {
                 if (self.quality == 100) {
                     // no scaling, no downsampling, this is the fastest option
@@ -215,7 +215,7 @@ typedef enum : NSUInteger {
                 break;
             } else {
                 if(self.outputType == BASE64_STRING){
-                    [result_all addObject:[data base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength]];
+                    [result_all addObject:[data base64EncodedStringWithOptions:0]];
                 } else {
                     [result_all addObject:[[NSURL fileURLWithPath:filePath] absoluteString]];
                 }


### PR DESCRIPTION
Hi,

In `SOSPicker.m`, you encoded image to `base64` with an option `NSDataBase64Encoding64CharacterLineLength`. This will insert a line ending at max length of 64. So the base64 string cannot be used directly as source to image tag.

To fix this, I remove that option and replace it with `0`. The conversion will be resulted in a string without any line ending.

**Changes**

```Objective-c
- (void)assetsPickerController:(GMImagePickerController *)picker didFinishPickingAssets:(NSArray *)fetchArray

...
[result_all addObject:[UIImageJPEGRepresentation(image, self.quality/100.0f) base64EncodedStringWithOptions:0]];

...

[result_all addObject:[data base64EncodedStringWithOptions:0]];
...

```