### PR TITLE
Create package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "version": "2.1.7",
+  "name": "cordova-plugin-googleplus",
+  "cordova_name": "ImagePicker",
+  "description": "This plugin allows selection of multiple images from the camera roll / gallery in a phonegap app",
+  "license": "MIT",
+  "repo": "https://github.com/kunalmestri9/ImagePicker",
+  "issue": "",
+  "keywords": [],
+  "platforms": [
+    "android",
+    "ios"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.5.0"
+    }
+  ]
+}


### PR DESCRIPTION
Fix For
We are getting this error because package does not have any package.json file.
For Cordova 7.0.0 

[ERROR] Cordova encountered an error.
        You may get more insight by running the Cordova command above directly.
        
[ERROR] An error occurred while running cordova plugin add https://github.com/Telerik-Verified-Plugins/ImagePicker --sav... (exit code 1):
        
        Error: Failed to fetch plugin https://github.com/Telerik-Verified-Plugins/ImagePicker via registry.
        Probably this is either a connection problem, or plugin spec is incorrect.
        Check your connection and plugin name/version/URL.
        Error: npm: Command failed with exit code 235 Error output:
        npm ERR! addLocal Could not install /tmp/npm-4042-b3a16daf/git-cache-0e4bbe6f/1d453300ae3dacb007a404fd59536afcb67ab286
        npm ERR! Darwin 15.5.0
        npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "https://github.com/Telerik-Verified-Plugins/ImagePicker" "--save"
        npm ERR! node v6.10.3
        npm ERR! npm  v3.10.10
        npm ERR! code EISDIR
        npm ERR! errno -21
        npm ERR! syscall read
