### PR TITLE
fix ImageFetcher for cordova-android 7.x

### DIFF
--- a/src/android/Library/src/ImageFetcher.java
+++ b/src/android/Library/src/ImageFetcher.java
@@ -290,7 +290,7 @@ public class ImageFetcher {
     private final HashMap<Integer, Bitmap> sHardBitmapCache = new LinkedHashMap<Integer, Bitmap>(
             HARD_CACHE_CAPACITY / 2, 0.75f, true) {
         @Override
-        protected boolean removeEldestEntry(LinkedHashMap.Entry<Integer, Bitmap> eldest) {
+        protected boolean removeEldestEntry(HashMap.Entry<Integer, Bitmap> eldest) {
             if (size() > HARD_CACHE_CAPACITY) {
                 // Entries push-out of hard reference cache are transferred to
                 // soft reference cache


### PR DESCRIPTION
fix platforms\android\app\src\main\java\com\synconset\ImageFetcher.java:293: error: Entry is not public in LinkedHashMap; cannot be accessed from outside package

        protected boolean removeEldestEntry(LinkedHashMap.Entry<Integer, Bitmap> eldest)

cf. https://github.com/Telerik-Verified-Plugins/ImagePicker/issues/99