### PR TITLE
Fix ClassNotFoundError accessing ImagePicker problem

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -94,7 +94,7 @@
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="ImagePicker">
-                <param name="android-package" value="cordova-plugin-telerik-imagepicker"/>
+                <param name="android-package" value="com.synconset.ImagePicker"/>
             </feature>
         </config-file>
 


### PR DESCRIPTION
Android PluginManager was enumerating ImagePicker as `cordova-plugin-telerik-imagepicker` which is not an instantiable class name.  This provides the correct data to allow the image picker to be used in Android (perhaps with v7.1?).

This problem has been occurring on cordova-android 7.1.0.