### PR TITLE
[BugFix] Fire cancel event from ios

### DIFF
--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -153,6 +153,11 @@ typedef enum : NSUInteger {
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
     [picker.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    [self.viewController dismissViewControllerAnimated:YES completion:nil];
+	CDVPluginResult* pluginResult = nil;
+    NSArray* emptyArray = [NSArray array];
+	pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:emptyArray];
+	[self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
     NSLog(@"UIImagePickerController: User pressed cancel button");
 }
 

--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -241,7 +241,12 @@ typedef enum : NSUInteger {
 //Optional implementation:
 -(void)assetsPickerControllerDidCancel:(GMImagePickerController *)picker
 {
-    NSLog(@"GMImagePicker: User pressed cancel button");
+   CDVPluginResult* pluginResult = nil;
+   NSArray* emptyArray = [NSArray array];
+   pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:emptyArray];
+   [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+   [picker.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+   NSLog(@"GMImagePicker: User pressed cancel button");
 }
 
 

--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -152,12 +152,11 @@ typedef enum : NSUInteger {
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
-    [picker.presentingViewController dismissViewControllerAnimated:YES completion:nil];
-    [self.viewController dismissViewControllerAnimated:YES completion:nil];
-	CDVPluginResult* pluginResult = nil;
+    CDVPluginResult* pluginResult = nil;
     NSArray* emptyArray = [NSArray array];
-	pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:emptyArray];
-	[self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:emptyArray];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    [self.viewController dismissViewControllerAnimated:YES completion:nil];
     NSLog(@"UIImagePickerController: User pressed cancel button");
 }
 


### PR DESCRIPTION
pretty straighforward, right now ionic promises do not return when the user cancels as no event was fired. This PR fixes that issue