### PR TITLE
ANDROID Prevents crashing when Importing in the non-default Orientation of app

### DIFF
--- a/src/android/Library/src/MultiImageChooserActivity.java
+++ b/src/android/Library/src/MultiImageChooserActivity.java
@@ -319,7 +319,7 @@ public class MultiImageChooserActivity extends AppCompatActivity implements
             progress.dismiss();
             finish();
         } else {
-	        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_NOSENSOR); //prevent orientation changes during processing
+            setRequestedOrientation(getResources().getConfiguration().orientation); //prevent orientation changes during processing
             new ResizeImagesTask().execute(fileNames.entrySet());
         }
     }


### PR DESCRIPTION
Photo Import was crashing when I was using Landscape mode when my app defaults to Portrait mode. This fixed it.