### PR TITLE
Fix - #86 Support Library configuration Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -107,7 +107,8 @@
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>
 
-        <framework src="com.android.support:appcompat-v7:23+" />
+        <preference name="ANDROID_SUPPORT_V7_VERSION" default="27.+"/>
+        <framework src="com.android.support:appcompat-v7:$ANDROID_SUPPORT_V7_VERSION" />
 
         <source-file src="src/android/com/synconset/ImagePicker/ImagePicker.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/ImagePicker/FakeR.java" target-dir="src/com/synconset" />


### PR DESCRIPTION
Now it is possible change support library version with ANDROID_SUPPORT_V7_VERSION variable (default value = 27.+);

config.xml:
`<plugin name="cordova-plugin-telerik-imagepicker" spec="https://github.com/Telerik-Verified-Plugins/ImagePicker.git"> <variable name="PHOTO_LIBRARY_USAGE_DESCRIPTION" value="your usage message" /> <variable name="ANDROID_SUPPORT_V7_VERSION" value="27.+" /> </plugin>`