### PR TITLE
Disabled fastscroll from grid layout

### DIFF
--- a/src/android/Library/res/layout/multiselectorgrid.xml
+++ b/src/android/Library/res/layout/multiselectorgrid.xml
@@ -11,7 +11,7 @@
         android:layout_weight="1"
         android:columnWidth="0dip"
         android:fadingEdgeLength="10dip"
-        android:fastScrollEnabled="true"
+        android:fastScrollEnabled="false"
         android:gravity="center"
         android:horizontalSpacing="8dip"
         android:numColumns="3"


### PR DESCRIPTION
This is a fast workaround for fastscroll bug on android with low resolution where when you try to click on the image on the right is easy to click on the fastscroll when you wan't.