### PR TITLE
Fixes crashes when localizedTitle is nil for album

### DIFF
--- a/src/ios/GMImagePicker/GMAlbumsViewController.m
+++ b/src/ios/GMImagePicker/GMAlbumsViewController.m
@@ -181,7 +181,7 @@ static NSString * const CollectionCellReuseIdentifier = @"CollectionCell";
             
             PHFetchResult *assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:options];
             [userFetchResultArray addObject:assetsFetchResult];
-            [userFetchResultLabel addObject:collection.localizedTitle];
+            [userFetchResultLabel addObject:collection.localizedTitle ?: @""];
         }
     }
     


### PR DESCRIPTION
This fixes #206 

Simply provides an empty string if localizedTitle is nil, instead of crashing.