### PR TITLE
Fix for missing activity error on platform re-add 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Note that backward compatibility was added by checking for read permission autom
 If permission is needed the plugin will now show the permission request popup.
 The user will then need to allow access and invoke the same method again after doing so.
 
+## Android 10 (Q) Permissions/Storage
+Android 10/11 included various [storage updates](https://developer.android.com/about/versions/11/privacy/storage).  This plugin is not fully compatible with these updates, and as such requires the `requestLegacyExternalStorage` property to be set in the android manifest in order to run on Android 10 devices.  This also will require targetting API level 29 (but this is already a google play store requirement as of November 2020).  
+
 
 ## Libraries used
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -92,14 +92,13 @@
 
     <!-- android -->
     <platform name="android">
+        <hook type="after_prepare" src="scripts/android_manifest_update.js" />
+
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="ImagePicker">
                 <param name="android-package" value="com.synconset.ImagePicker"/>
             </feature>
         </config-file>
-        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
-            <application android:requestLegacyExternalStorage="true" />
-        </edit-config>
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <activity android:label="@string/multi_app_name" android:name="com.synconset.MultiImageChooserActivity" android:theme="@style/Theme.AppCompat.Light">
             </activity>

--- a/scripts/android_manifest_update.js
+++ b/scripts/android_manifest_update.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+module.exports = function (context) {
+
+    var fs = require('fs');
+    var path = require('path');
+    var manifestDirectory = path.join(context.opts.projectRoot, '/platforms/android/app/src/main/');
+    var manifestFile = path.join(manifestDirectory, 'AndroidManifest.xml');
+
+    var LEGACY_STORAGE_ATTRIBUTE = 'android:requestLegacyExternalStorage';
+    var LEGACY_STORAGE_VALUE = LEGACY_STORAGE_ATTRIBUTE + '="true"';
+    var LEGACY_STORAGE_REGEX = new RegExp(LEGACY_STORAGE_ATTRIBUTE + '="([^"]+)"');
+
+    fs.exists(manifestDirectory, function (exists) {
+        if (!exists) {
+            console.log('Manifest directory not found. No image-picker updates.');
+        }
+        else {
+
+            fs.readFile(manifestFile, 'utf8', function (err, data) {
+                if (err) {
+                    throw new Error('Unable to read AndroidManifest.xml: ' + err);
+                }
+
+                var updatedManifest;
+
+                //Add the android:requestLegacyExternalStorage value in the manifest
+                if (!data.match(LEGACY_STORAGE_ATTRIBUTE)) {
+                    updatedManifest = data.replace(/<application/g, '<application ' + LEGACY_STORAGE_VALUE + ' ');
+                }
+                //update the android:requestLegacyExternalStorage value in the manifest, if it's not set to true
+                else if (data.match(LEGACY_STORAGE_REGEX) && !data.match(LEGACY_STORAGE_VALUE)) {
+                    updatedManifest = data.replace(LEGACY_STORAGE_REGEX, LEGACY_STORAGE_VALUE);
+                }
+
+                //Update the actual file - write it out
+                if (updatedManifest) {
+                    fs.writeFile(manifestFile, updatedManifest, 'utf8', function (err) {
+                        if (err) throw new Error('Unable to write AndroidManifest.xml: ' + err);
+                    })
+                }
+            });
+        }
+    });
+}


### PR DESCRIPTION
When this plugin is already added, and you do a `platform remove` and then a `platform add`, the <activity> node is not added to the android manifest (like it should [here](https://github.com/Telerik-Verified-Plugins/ImagePicker/blob/c7c866cd4133e78a3479a1d832f88da413e62dc3/plugin.xml#L100)).  Removing the plugin and re-adding it seems to fix it, but this should not be needed.  With no activity in the manifest, the end result is a successful build, but using the plugin results in this error:

`Unable to find explicit activity class {....synconset.MultiImageChooserActivity}; have you declared this activity in your AndroidManifest.xml?`

This PR is assuming that the problem is `<edit-config>` being buggy in cordova.  The PR moves to a hook approach of manually adding this `requestLegacyExternalStorage` element.  The buggy assumption is documented in the tickets below.

More details can be found in tickets below:

- https://github.com/Telerik-Verified-Plugins/ImagePicker/issues/165
- https://github.com/Telerik-Verified-Plugins/ImagePicker/issues/228