### PR TITLE
fix: on iOS requestReadPermission returns an invalid result before us…

### DIFF
--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -49,11 +49,27 @@ typedef enum : NSUInteger {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     } else if (status == PHAuthorizationStatusNotDetermined) {
-        // Access has not been determined. requestAuthorization: is available
-        [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {}];
-        
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        // Access has not been determined. requestAuthorization: is available, ask.
+        [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+            if (status == PHAuthorizationStatusAuthorized) {
+                NSLog(@"Access has been granted.");
+
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            } else if (status == PHAuthorizationStatusDenied) {
+                NSString* message = @"Access has been denied. Change your setting > this app > Photo enable";
+                NSLog(@"%@", message);
+
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            } else if (status == PHAuthorizationStatusRestricted) {
+                NSString* message = @"Access has been restricted. Change your setting > Privacy > Photo enable";
+                NSLog(@"%@", message);
+
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            }
+        }];
     } else if (status == PHAuthorizationStatusRestricted) {
         NSString* message = @"Access has been restricted. Change your setting > Privacy > Photo enable";
         NSLog(@"%@", message);

--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -40,7 +40,7 @@ typedef enum : NSUInteger {
     if (status == PHAuthorizationStatusAuthorized) {
         NSLog(@"Access has been granted.");
         
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     } else if (status == PHAuthorizationStatusDenied) {
         NSString* message = @"Access has been denied. Change your setting > this app > Photo enable";
@@ -54,7 +54,7 @@ typedef enum : NSUInteger {
             if (status == PHAuthorizationStatusAuthorized) {
                 NSLog(@"Access has been granted.");
 
-                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             } else if (status == PHAuthorizationStatusDenied) {
                 NSString* message = @"Access has been denied. Change your setting > this app > Photo enable";


### PR DESCRIPTION
…er has answered the permission request.

This fixes the issue on iOS when requesting read permission. If the user has not been previously asked for permission, iOS will display an alert to the user requesting their permission while the requestReadPermission function returns null before the user has answered the question.
